### PR TITLE
Removed -HostArch from utf8proc-build script

### DIFF
--- a/utf8proc-build/Build-utf8proc.ps1
+++ b/utf8proc-build/Build-utf8proc.ps1
@@ -62,7 +62,7 @@ Import-Module $vsDevShellPath
 
 $vsInstallPath = $(Join-Path -Path $vsDirectory -ChildPath "..\..")
 $machineArch = $Env:Processor_Architecture
-Enter-VsDevShell -VsInstallPath "$vsInstallPath" -Arch $machineArch -HostArch $machineArch -StartInPath $(Get-Location)
+Enter-VsDevShell -VsInstallPath "$vsInstallPath" -Arch $machineArch -StartInPath $(Get-Location)
 
 # Check for CMakePresets.json
 if (-not (Test-Path -Path $CMakePresets)) {


### PR DESCRIPTION
- Causes failure to launch VS dev shell on ARM64, tricky to detect