### PR TITLE
Fixed hang on unhandled escape sequences

### DIFF
--- a/AnsiProcessor/AnsiProcessor.csproj
+++ b/AnsiProcessor/AnsiProcessor.csproj
@@ -10,6 +10,8 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Karambolo.Extensions.Logging.File" Version="3.6.3" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="9.0.7" />
     <PackageReference Include="Microsoft.Windows.CsWin32" Version="0.3.183">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/AnsiProcessor/LoggerHelper.cs
+++ b/AnsiProcessor/LoggerHelper.cs
@@ -1,0 +1,88 @@
+﻿using Microsoft.Extensions.Logging;
+using System;
+
+namespace Spakov.AnsiProcessor
+{
+    /// <summary>
+    /// Logging-related helper methods.
+    /// </summary>
+    internal static class LoggerHelper
+    {
+        /// <summary>
+        /// The library logging level to use.
+        /// </summary>
+        internal static readonly LogLevel s_logLevel = LogLevel.None;
+
+        /// <summary>
+        /// Creates a logger for <typeparamref name="T"/>.
+        /// </summary>
+        /// <remarks>Generates output in <see cref="AppContext.BaseDirectory"/>
+        /// in a file named <c>typeof(T).Name</c>.</remarks>
+        /// <typeparam name="T">A class to associate with the
+        /// logger.</typeparam>
+        /// <returns>An <see cref="ILogger"/>, if this is a debug build, or
+        /// <see langword="null"/> otherwise.</returns>
+        internal static ILogger? CreateLogger<T>()
+        {
+#if DEBUG
+            ILoggerFactory factory = LoggerFactory.Create(
+                builder =>
+                {
+                    builder.AddFile(options =>
+                    {
+                        options.RootPath = AppContext.BaseDirectory;
+                        options.BasePath = "Logs";
+                        options.FileAccessMode = Karambolo.Extensions.Logging.File.LogFileAccessMode.KeepOpenAndAutoFlush;
+                        options.Files =
+                        [
+                            new Karambolo.Extensions.Logging.File.LogFileOptions() { Path = $"{typeof(T).Name}.log" }
+                        ];
+                    });
+                    builder.SetMinimumLevel(s_logLevel);
+                }
+            );
+
+            return factory.CreateLogger<T>();
+#else
+            return null;
+#endif
+        }
+
+        /// <summary>
+        /// Attempts to invoke <paramref name="func"/>, logging <paramref
+        /// name="exceptionLogMessage"/> if it throws any exception.
+        /// </summary>
+        /// <remarks>Simply invokes <paramref name="func"/> if <paramref
+        /// name="logger"/> is <see langword="null"/>.</remarks>
+        /// <typeparam name="T"><paramref name="func"/>'s return
+        /// type.</typeparam>
+        /// <param name="func">A function.</param>
+        /// <param name="exceptionLogMessage">The message to log if an
+        /// exception is caught.</param>
+        /// <param name="logger">An <see cref="ILogger"/>.</param>
+        /// <returns>A <see cref="ValueTuple{T1, T2}"/> indicating whether an
+        /// exception was thrown and <paramref name="func"/>'s return
+        /// value.</returns>
+        internal static (bool, T?) LogTry<T>(Func<T> func, string exceptionLogMessage, ILogger? logger = null)
+        {
+            if (logger != null)
+            {
+                try
+                {
+                    T? returnValue = func();
+                    return (false, returnValue);
+                }
+                catch (Exception e)
+                {
+                    logger.LogError(e, "{exceptionLogMessage}", exceptionLogMessage);
+
+                    return (true, default!);
+                }
+            }
+            else
+            {
+                return (false, func());
+            }
+        }
+    }
+}

--- a/AnsiProcessor/TermCap/EscapeSequences.cs
+++ b/AnsiProcessor/TermCap/EscapeSequences.cs
@@ -29,7 +29,7 @@ namespace Spakov.AnsiProcessor.TermCap
         public List<char> Fp { get; } =
         [
             Ansi.EscapeSequences.Fp.DECSC,
-            Ansi.EscapeSequences.Fp.DECRC,
+            Ansi.EscapeSequences.Fp.DECRC
         ];
 
         /// <summary>

--- a/docs/vttest-results.md
+++ b/docs/vttest-results.md
@@ -70,6 +70,7 @@ Items annotated with * are very likely due to being handled by ConPTY.
 - **1** Test of cursor movements (132-column mode not implemented)
 - **2** Test of screen features (132-column mode not implemented)
 - **5.4** Keyboard Tests -&gt; Cursor Keys (&lt;ANSI / Cursor key mode RESET&gt;, &lt;ANSI / Cursor key mode SET&gt; pass, &lt;VT52 Mode&gt; not implemented)
+- **5.5** Keyboard Tests -&gt; Numeric Keypad (&lt;ANSI Application mode&gt;, &lt;VT52 Application mode&gt; not implemented)
 - **7** Test of VT52 mode (partially handled by ConPTY, not implemented)
 - **8** Test of VT102 features (Insert/Delete Char/Line) (double-width mode not implemented, 132-column mode not implemented)
 - **11.1.3** VT220 Tests -&gt; Test 8-bit controls (S7C1T/S8C1T) (8-bit control support not implemented, 7-bit control support pass)
@@ -119,7 +120,6 @@ Items annotated with * are very likely due to being handled by ConPTY.
 ### Fail
 - **4** Test of double-sized characters (not implemented)
 - **5.1** Keyboard Tests -&gt; LED Lights (not implemented)
-- **5.5** Keyboard Tests -&gt; Numeric Keypad (hangs the terminal)
 - **5.8** Keyboard Tests -&gt; AnswerBack (not implemented)
 - **6.1** Terminal Reports/Responses -&gt; &lt;ENQ&gt; (AnswerBack Message) (not implemented)
 - **11.1.1.1.4** VT220 Device Status Reports -&gt; Test UDK Status (not implemented)


### PR DESCRIPTION
- In AnsiReader, escape sequences that are not handled but are expected to be no longer hang the AnsiReader
- This was the case with ESC =, Application Keypad (DECKPAM), for instance
- vttest 5.5 is now a partial pass and no longer hangs the terminal