### PR TITLE
Transparency now works "right" with ASB

### DIFF
--- a/Terminal/Cell.cs
+++ b/Terminal/Cell.cs
@@ -21,6 +21,12 @@ namespace Spakov.Terminal
         public GraphicRendition GraphicRendition;
 
         /// <summary>
+        /// Whether this <see cref="Cell"/> is eligible to be rendered with a
+        /// transparent background.
+        /// </summary>
+        public bool TransparentEligible;
+
+        /// <summary>
         /// Whether this <see cref="Cell"/> is selected.
         /// </summary>
         public bool Selected;
@@ -38,6 +44,11 @@ namespace Spakov.Terminal
                 return false;
             }
 
+            if (a.TransparentEligible != b.TransparentEligible)
+            {
+                return false;
+            }
+
             if (a.Selected != b.Selected)
             {
                 return false;
@@ -50,6 +61,6 @@ namespace Spakov.Terminal
 
         public override readonly bool Equals([NotNullWhen(true)] object? obj) => obj is Cell other && this == other;
 
-        public override readonly int GetHashCode() => HashCode.Combine(GraphemeCluster, GraphicRendition, Selected);
+        public override readonly int GetHashCode() => HashCode.Combine(GraphemeCluster, GraphicRendition, TransparentEligible, Selected);
     }
 }

--- a/Terminal/TerminalRenderer.cs
+++ b/Terminal/TerminalRenderer.cs
@@ -1214,7 +1214,7 @@ namespace Spakov.Terminal
                 : drawableCell.Cell.GraphicRendition.CalculatedBackgroundColor(
                     defaultBackgroundColor,
                     backgroundIsInvisible,
-                    honorBackgroundIsInvisible: !_terminalEngine.UseAlternateScreenBuffer
+                    honorBackgroundIsInvisible: drawableCell.Cell.TransparentEligible
                 );
 
             drawingSession.Blend = CanvasBlend.Copy;

--- a/Terminal/VideoTerminal.ProcessEscapeSequence.cs
+++ b/Terminal/VideoTerminal.ProcessEscapeSequence.cs
@@ -75,9 +75,12 @@ namespace Spakov.Terminal
                                     }
                                     else
                                     {
+                                        _transparentEligible = _graphicRendition.BackgroundColor == Palette.DefaultBackgroundColor;
+
                                         _screenBuffer[row][col] = new()
                                         {
-                                            GraphicRendition = _graphicRendition
+                                            GraphicRendition = _graphicRendition,
+                                            TransparentEligible = _transparentEligible
                                         };
 
                                         if (_terminalEngine.UseBackgroundColorErase)
@@ -121,9 +124,12 @@ namespace Spakov.Terminal
                                     }
                                     else
                                     {
+                                        _transparentEligible = _graphicRendition.BackgroundColor == Palette.DefaultBackgroundColor;
+
                                         _screenBuffer[row][col] = new()
                                         {
-                                            GraphicRendition = _graphicRendition
+                                            GraphicRendition = _graphicRendition,
+                                            TransparentEligible = _transparentEligible
                                         };
 
                                         if (_terminalEngine.UseBackgroundColorErase)
@@ -351,6 +357,8 @@ namespace Spakov.Terminal
 
                     // Delete character (P)
                     case CSI.DCH:
+                        _transparentEligible = _graphicRendition.BackgroundColor == Palette.DefaultBackgroundColor;
+
                         if (_autoWrapMode)
                         {
                             WrapPending = false;
@@ -360,7 +368,8 @@ namespace Spakov.Terminal
                         {
                             _screenBuffer[Row][Column] = new()
                             {
-                                GraphicRendition = _graphicRendition
+                                GraphicRendition = _graphicRendition,
+                                TransparentEligible = _transparentEligible
                             };
 
                             if (_terminalEngine.UseBackgroundColorErase)
@@ -405,12 +414,14 @@ namespace Spakov.Terminal
                                     }
 
                                     _screenBuffer.Add(new Cell[_terminalEngine.Columns]);
+                                    _transparentEligible = _graphicRendition.BackgroundColor == Palette.DefaultBackgroundColor;
 
                                     for (int col = 0; col < _terminalEngine.Columns; col++)
                                     {
                                         _screenBuffer[_terminalEngine.Rows - 1][col] = new()
                                         {
-                                            GraphicRendition = _graphicRendition
+                                            GraphicRendition = _graphicRendition,
+                                            TransparentEligible = _transparentEligible
                                         };
 
                                         if (_terminalEngine.UseBackgroundColorErase)
@@ -442,12 +453,14 @@ namespace Spakov.Terminal
                                 }
 
                                 _screenBuffer.Insert(0, new Cell[_terminalEngine.Columns]);
+                                _transparentEligible = _graphicRendition.BackgroundColor == Palette.DefaultBackgroundColor;
 
                                 for (int col = 0; col < _terminalEngine.Columns; col++)
                                 {
                                     _screenBuffer[_terminalEngine.Rows - 1][col] = new()
                                     {
-                                        GraphicRendition = _graphicRendition
+                                        GraphicRendition = _graphicRendition,
+                                        TransparentEligible = _transparentEligible
                                     };
 
                                     if (_terminalEngine.UseBackgroundColorErase)
@@ -473,6 +486,8 @@ namespace Spakov.Terminal
                             WrapPending = false;
                         }
 
+                        _transparentEligible = _graphicRendition.BackgroundColor == Palette.DefaultBackgroundColor;
+
                         if (csiEscapeSequence.Ps![0] < 1)
                         {
                             csiEscapeSequence.Ps![0] = 1;
@@ -482,7 +497,8 @@ namespace Spakov.Terminal
                         {
                             _screenBuffer[Row][j] = new()
                             {
-                                GraphicRendition = _graphicRendition
+                                GraphicRendition = _graphicRendition,
+                                TransparentEligible = _transparentEligible
                             };
 
                             if (_terminalEngine.UseBackgroundColorErase)
@@ -683,6 +699,7 @@ namespace Spakov.Terminal
                             _originMode = false;
 
                             _graphicRendition.InitializeFromPalette(_palette);
+                            _transparentEligible = _graphicRendition.BackgroundColor == Palette.DefaultBackgroundColor;
 
                             if (_terminalEngine.UseBackgroundColorErase)
                             {
@@ -2042,6 +2059,7 @@ namespace Spakov.Terminal
                     _savedCursorPosition = null;
 
                     _graphicRendition.InitializeFromPalette(_palette);
+                    _transparentEligible = _graphicRendition.BackgroundColor == Palette.DefaultBackgroundColor;
 
                     if (_terminalEngine.UseBackgroundColorErase)
                     {

--- a/Terminal/VideoTerminal.cs
+++ b/Terminal/VideoTerminal.cs
@@ -45,6 +45,7 @@ namespace Spakov.Terminal
 
         private GraphicRendition _graphicRendition;
         private Palette _palette;
+        private bool _transparentEligible;
         private System.Drawing.Color _backgroundColorErase;
 
         private readonly List<Cell[]> _alternateScreenBuffer;
@@ -266,6 +267,7 @@ namespace Spakov.Terminal
             _graphicRendition = new();
             _palette = terminalEngine.Palette!;
             _graphicRendition.InitializeFromPalette(_palette);
+            _transparentEligible = true;
 
             if (terminalEngine.UseBackgroundColorErase)
             {
@@ -528,6 +530,7 @@ namespace Spakov.Terminal
             {
                 GraphemeCluster = graphemeCluster,
                 GraphicRendition = _graphicRendition,
+                TransparentEligible = _transparentEligible
             };
 
             if (graphemeClusterWidth > 1)
@@ -553,6 +556,7 @@ namespace Spakov.Terminal
                 {
                     GraphemeCluster = null,
                     GraphicRendition = _graphicRendition,
+                    TransparentEligible = _transparentEligible
                 };
             }
 
@@ -1531,12 +1535,14 @@ namespace Spakov.Terminal
                 else
                 {
                     _screenBuffer.Add(new Cell[_terminalEngine.Columns]);
+                    _transparentEligible = _graphicRendition.BackgroundColor == Palette.DefaultBackgroundColor;
 
                     for (int col = 0; col < _terminalEngine.Columns; col++)
                     {
                         _screenBuffer[_terminalEngine.Rows - 1][col] = new()
                         {
-                            GraphicRendition = _graphicRendition
+                            GraphicRendition = _graphicRendition,
+                            TransparentEligible = _transparentEligible
                         };
 
                         if (_terminalEngine.UseBackgroundColorErase)
@@ -1607,12 +1613,14 @@ namespace Spakov.Terminal
                 else
                 {
                     _screenBuffer.Insert(0, new Cell[_terminalEngine.Columns]);
+                    _transparentEligible = _graphicRendition.BackgroundColor == Palette.DefaultBackgroundColor;
 
                     for (int col = 0; col < _terminalEngine.Columns; col++)
                     {
                         _screenBuffer[0][col] = new()
                         {
-                            GraphicRendition = _graphicRendition
+                            GraphicRendition = _graphicRendition,
+                            TransparentEligible = _transparentEligible
                         };
 
                         if (_terminalEngine.UseBackgroundColorErase)
@@ -1673,6 +1681,7 @@ namespace Spakov.Terminal
             for (int row = 0; row < buffer.Count; row++)
             {
                 Cell[] newRow = new Cell[_terminalEngine.Columns];
+                _transparentEligible = _graphicRendition.BackgroundColor == Palette.DefaultBackgroundColor;
 
                 for (int col = 0; col < Math.Min(buffer[row].Length, _terminalEngine.Columns); col++)
                 {
@@ -1683,7 +1692,8 @@ namespace Spakov.Terminal
                 {
                     newRow[col] = new()
                     {
-                        GraphicRendition = _graphicRendition
+                        GraphicRendition = _graphicRendition,
+                        TransparentEligible = _transparentEligible
                     };
 
                     if (_terminalEngine.UseBackgroundColorErase)
@@ -1704,6 +1714,9 @@ namespace Spakov.Terminal
 
                     for (int col = 0; col < _terminalEngine.Columns; col++)
                     {
+                        // Note that we do *not* adjust the new cell's graphic
+                        // rendition here; these appeared out of nowhere in a
+                        // place that doesn't match "now"
                         buffer[row][col] = new();
 
                         if (_terminalEngine.UseBackgroundColorErase)
@@ -1766,6 +1779,8 @@ namespace Spakov.Terminal
         /// <param name="screenClearType">The type of screen clear.</param>
         private void ClearScreen(ScreenClearType screenClearType)
         {
+            _transparentEligible = _graphicRendition.BackgroundColor == Palette.DefaultBackgroundColor;
+
             switch (screenClearType)
             {
                 case ScreenClearType.Before:
@@ -1777,7 +1792,8 @@ namespace Spakov.Terminal
                             {
                                 _screenBuffer[i][j] = new()
                                 {
-                                    GraphicRendition = _graphicRendition
+                                    GraphicRendition = _graphicRendition,
+                                    TransparentEligible = _transparentEligible
                                 };
 
                                 if (_terminalEngine.UseBackgroundColorErase)
@@ -1792,7 +1808,8 @@ namespace Spakov.Terminal
                             {
                                 _screenBuffer[i][j] = new()
                                 {
-                                    GraphicRendition = _graphicRendition
+                                    GraphicRendition = _graphicRendition,
+                                    TransparentEligible = _transparentEligible
                                 };
 
                                 if (_terminalEngine.UseBackgroundColorErase)
@@ -1814,7 +1831,8 @@ namespace Spakov.Terminal
                             {
                                 _screenBuffer[i][j] = new()
                                 {
-                                    GraphicRendition = _graphicRendition
+                                    GraphicRendition = _graphicRendition,
+                                    TransparentEligible = _transparentEligible
                                 };
 
                                 if (_terminalEngine.UseBackgroundColorErase)
@@ -1829,7 +1847,8 @@ namespace Spakov.Terminal
                             {
                                 _screenBuffer[i][j] = new()
                                 {
-                                    GraphicRendition = _graphicRendition
+                                    GraphicRendition = _graphicRendition,
+                                    TransparentEligible = _transparentEligible
                                 };
 
                                 if (_terminalEngine.UseBackgroundColorErase)
@@ -1850,7 +1869,8 @@ namespace Spakov.Terminal
                         {
                             _screenBuffer[i][j] = new()
                             {
-                                GraphicRendition = _graphicRendition
+                                GraphicRendition = _graphicRendition,
+                                TransparentEligible = _transparentEligible
                             };
 
                             if (_terminalEngine.UseBackgroundColorErase)
@@ -1876,6 +1896,8 @@ namespace Spakov.Terminal
         /// <param name="lineClearType">The type of line clear.</param>
         private void ClearLine(LineClearType lineClearType)
         {
+            _transparentEligible = _graphicRendition.BackgroundColor == Palette.DefaultBackgroundColor;
+
             switch (lineClearType)
             {
                 case LineClearType.Before:
@@ -1883,7 +1905,8 @@ namespace Spakov.Terminal
                     {
                         _screenBuffer[Row][j] = new()
                         {
-                            GraphicRendition = _graphicRendition
+                            GraphicRendition = _graphicRendition,
+                            TransparentEligible = _transparentEligible
                         };
 
                         if (_terminalEngine.UseBackgroundColorErase)
@@ -1899,7 +1922,8 @@ namespace Spakov.Terminal
                     {
                         _screenBuffer[Row][j] = new()
                         {
-                            GraphicRendition = _graphicRendition
+                            GraphicRendition = _graphicRendition,
+                            TransparentEligible = _transparentEligible
                         };
 
                         if (_terminalEngine.UseBackgroundColorErase)
@@ -1915,7 +1939,8 @@ namespace Spakov.Terminal
                     {
                         _screenBuffer[Row][j] = new()
                         {
-                            GraphicRendition = _graphicRendition
+                            GraphicRendition = _graphicRendition,
+                            TransparentEligible = _transparentEligible
                         };
 
                         if (_terminalEngine.UseBackgroundColorErase)


### PR DESCRIPTION
- Transparency re-enabled in ASB
- Default background colors are transparent when they're actually the background, but not otherwise
- Menus and so on in nvim are no longer transparent, e.g.